### PR TITLE
Fixed memory leak

### DIFF
--- a/src/main/java/com/andraskindler/parallaxviewpager/ParallaxViewPager.java
+++ b/src/main/java/com/andraskindler/parallaxviewpager/ParallaxViewPager.java
@@ -39,6 +39,14 @@ public class ParallaxViewPager extends ViewPager {
         init();
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (bitmap != null && !bitmap.isRecycled()) {
+            bitmap = null;
+        }
+    }
+
     private void init() {
         source = new Rect();
         destination = new Rect();


### PR DESCRIPTION
When the view pager is detached from a window, it will leak the memory
of the bitmap since the bitmap is not being set to null. This fixes
that issue and clears the bitmap memory when the view pager is detached.
